### PR TITLE
block: maple: Fix inverted logic, Revert 'Remove CONFIG_HZ dependency'

### DIFF
--- a/block/maple-iosched.c
+++ b/block/maple-iosched.c
@@ -19,15 +19,15 @@
 #include <linux/slab.h>
 #include <linux/display_state.h>
 
-#define MAPLE_IOSCHED_PATCHLEVEL	(6)
+#define MAPLE_IOSCHED_PATCHLEVEL	(7)
 
 enum { ASYNC, SYNC };
 
 /* Tunables */
-static const int sync_read_expire = 100;	/* max time before a read sync is submitted. */
-static const int sync_write_expire = 350;	/* max time before a write sync is submitted. */
-static const int async_read_expire = 200;	/* ditto for read async, these limits are SOFT! */
-static const int async_write_expire = 500;	/* ditto for write async, these limits are SOFT! */
+static const int sync_read_expire = HZ/3;	/* max time before a read sync is submitted. */
+static const int sync_write_expire = 7*HZ/6;	/* max time before a write sync is submitted. */
+static const int async_read_expire = 2*HZ/3;	/* ditto for read async, these limits are SOFT! */
+static const int async_write_expire = 5*HZ/3;	/* ditto for write async, these limits are SOFT! */
 static const int fifo_batch = 16;		/* # of sequential requests treated as one by the above parameters. */
 static const int writes_starved = 3;		/* max times reads can starve a write */
 static const int sleep_latency_multiple = 5;	/* multple for expire time when device is asleep */
@@ -90,7 +90,7 @@ maple_add_request(struct request_queue *q, struct request *rq)
    	if (display_on && mdata->fifo_expire[sync][dir]) {
    		rq_set_fifo_time(rq, jiffies + mdata->fifo_expire[sync][dir]);
    		list_add_tail(&rq->queuelist, &mdata->fifo_list[sync][dir]);
-   	} else if (display_on && fifo_expire_suspended) {
+   	} else if (!display_on && fifo_expire_suspended) {
    		rq_set_fifo_time(rq, jiffies + fifo_expire_suspended);
    		list_add_tail(&rq->queuelist, &mdata->fifo_list[sync][dir]);
    	}


### PR DESCRIPTION
Maple Patch level 7.

Revert maple commit https://github.com/frap129/angler/commit/b84fa479043f5fb95a9bc79a84763c07a54bcdf4 for better cross device compatibility
